### PR TITLE
Fix #7; manage chap-secrets file

### DIFF
--- a/manifests/connections.pp
+++ b/manifests/connections.pp
@@ -3,6 +3,19 @@
 # Manage the client connections
 #
 class pptp::connections {
+
+  file { '/etc/ppp/chap-secrets':
+    ensure   => file,
+    owner    => 'root',
+    group    => 'root',
+    mode     => '0600',
+    seluser  => 'system_u',
+    selrole  => 'object_r',
+    seltype  => 'usr_t',
+    selrange => 's0',
+    content  => template('pptp/chap-secrets.epp'),
+  }
+
   if defined('$pptp::connections') {
     $pptp::connections.each |$connection| {
       file { $connection['name']:

--- a/spec/classes/pptp_spec.rb
+++ b/spec/classes/pptp_spec.rb
@@ -10,6 +10,14 @@ describe 'pptp' do
       it { is_expected.to contain_class('pptp::install') }
       it { is_expected.to contain_class('pptp::service') }
       it { is_expected.to contain_class('pptp::connections') }
+      it { is_expected.to contain_file('/etc/ppp/chap-secrets') }
+
+      it { is_expected.to contain_class('kmod') }
+      it { is_expected.to contain_kmod__load('ppp_mppe') }
+      it { is_expected.to contain_file('/etc/modules-load.d/pptp.conf') }
+
+      it { is_expected.to contain_file('/sbin/pon') }
+      it { is_expected.to contain_file('/sbin/poff') }
 
       case os_facts[:osfamily]
       when 'Debian'
@@ -21,6 +29,7 @@ describe 'pptp' do
       when 'Suse'
         it { is_expected.to contain_package('pptp') }
         it { is_expected.not_to contain_class('firewalld') }
+        it { is_expected.to contain_file('/etc/sysconfig/kernel') }
       end
     end
 
@@ -37,7 +46,26 @@ describe 'pptp' do
       it { is_expected.to contain_class('pptp::install') }
       it { is_expected.to contain_class('pptp::service') }
       it { is_expected.to contain_class('pptp::connections') }
+      it { is_expected.to contain_file('/etc/ppp/chap-secrets') }
+
+      it { is_expected.to contain_class('kmod') }
+      it { is_expected.to contain_kmod__load('ppp_mppe') }
+      it { is_expected.to contain_file('/etc/modules-load.d/pptp.conf') }
+
       it { is_expected.not_to contain_class('firewalld') }
+
+      it { is_expected.to contain_file('/sbin/pon') }
+      it { is_expected.to contain_file('/sbin/poff') }
+
+      case os_facts[:osfamily]
+      when 'Debian'
+        it { is_expected.to contain_package('pptp-linux') }
+      when 'RedHat'
+        it { is_expected.to contain_package('pptp') }
+      when 'Suse'
+        it { is_expected.to contain_package('pptp') }
+        it { is_expected.to contain_file('/etc/sysconfig/kernel') }
+      end
     end
 
     context "on #{os} with package management disabled" do
@@ -53,16 +81,26 @@ describe 'pptp' do
       it { is_expected.to contain_class('pptp::install') }
       it { is_expected.to contain_class('pptp::service') }
       it { is_expected.to contain_class('pptp::connections') }
+      it { is_expected.to contain_file('/etc/ppp/chap-secrets') }
+
+      it { is_expected.to contain_class('kmod') }
+      it { is_expected.to contain_kmod__load('ppp_mppe') }
+      it { is_expected.to contain_file('/etc/modules-load.d/pptp.conf') }
+
       it { is_expected.not_to contain_file('/sbin/pon') }
       it { is_expected.not_to contain_file('/sbin/poff') }
 
       case os_facts[:osfamily]
       when 'Debian'
         it { is_expected.not_to contain_package('pptp-linux') }
+        it { is_expected.to contain_class('firewalld') }
       when 'RedHat'
         it { is_expected.not_to contain_package('pptp') }
+        it { is_expected.to contain_class('firewalld') }
       when 'Suse'
         it { is_expected.not_to contain_package('pptp') }
+        it { is_expected.not_to contain_class('firewalld') }
+        it { is_expected.to contain_file('/etc/sysconfig/kernel') }
       end
     end
 
@@ -79,12 +117,25 @@ describe 'pptp' do
       it { is_expected.to contain_class('pptp::install') }
       it { is_expected.to contain_class('pptp::service') }
       it { is_expected.to contain_class('pptp::connections') }
+      it { is_expected.to contain_file('/etc/ppp/chap-secrets') }
+
       it { is_expected.not_to contain_class('kmod') }
       it { is_expected.not_to contain_kmod__load('ppp_mppe') }
       it { is_expected.not_to contain_file('/etc/modules-load.d/pptp.conf') }
 
+      it { is_expected.to contain_file('/sbin/pon') }
+      it { is_expected.to contain_file('/sbin/poff') }
+
       case os_facts[:osfamily]
+      when 'Debian'
+        it { is_expected.to contain_package('pptp-linux') }
+        it { is_expected.to contain_class('firewalld') }
+      when 'RedHat'
+        it { is_expected.to contain_package('pptp') }
+        it { is_expected.to contain_class('firewalld') }
       when 'Suse'
+        it { is_expected.to contain_package('pptp') }
+        it { is_expected.not_to contain_class('firewalld') }
         it { is_expected.not_to contain_file('/etc/sysconfig/kernel') }
       end
     end

--- a/templates/chap-secrets.epp
+++ b/templates/chap-secrets.epp
@@ -1,0 +1,4 @@
+<%# /etc/ppp/chap-secrets template -%>
+<% $pptp::connections.each |$connection| { -%>
+<%= connection['username'] %> PPTP <%= connection['password'] %> *
+<% } -%>


### PR DESCRIPTION
This changes begin to manage the /etc/ppp/chap-secrets file.

The integrations tests were inproved.